### PR TITLE
Support for executables with more sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,5 @@ Detects code differentials between executables in disk and the corresponding pro
     python windows_memory_patches.py
     
 ## Notes
-    The script needs Administrator/SYSTEM privileges in order to analyze all the processes in memory
+    The script needs Administrator/SYSTEM privileges in order to analyze all the processes in memory.
+    At the moment, it doesn't check WoW64 processes at all.

--- a/windows_memory_patches.py
+++ b/windows_memory_patches.py
@@ -7,7 +7,6 @@ from itertools import groupby
 from ctypes import *
 from ctypes.wintypes import DWORD, HMODULE, MAX_PATH, BYTE, ULONG, HANDLE, USHORT
 import ctypes, psutil, threading
-import win32con
 from capstone import *
 
 NTDLL = ctypes.windll.ntdll
@@ -100,7 +99,7 @@ def get_relocations(pe, proc, moduleBaseAddress):
 
         return relocations
     except Exception as ex:
-        print str(ex)
+        print(str(ex))
 
 def analyze_process(pid):
     proc = winappdbg.Process(pid)
@@ -175,18 +174,18 @@ def analyze_process(pid):
                 process_patches['modules'].append(module_obj)
         except OSError as ex:
             if ex.winerror != 299:
-                print str(ex)
+                print(str(ex))
     return process_patches
 
 def print_process_patches(process_patches):
-    print "Patches in PID %s, File %s" % (process_patches['pid'], process_patches['file'])
+    print("Patches in PID {0}, File {1}".format(process_patches['pid'], process_patches['file']))
     for module in process_patches['modules']:
-        print "Module %s" % module['file']
+        print("Module {}".format(module['file']))
         for patch in module['patches']:
-            print "Disk Code: "
-            print patch['disk_code']
-            print "Memory Code: "
-            print patch['mem_code']
+            print("Disk Code: ")
+            print("{}".format(patch['disk_code']))
+            print("Memory Code: ")
+            print("{}".format(patch['mem_code'])
     
 
 def get_process_patches(process_id=None):
@@ -203,11 +202,11 @@ def get_process_patches(process_id=None):
                 print_process_patches(process_patches)
                 processes_patches.append(process_patches)
             else:
-                print "No patches in process ID: %s" % pid
+                print("No patches in process ID: {}".format(pid)
         except Exception as ex:
-            print "Error analyzing process ID: %s" % pid
+            print("Error analyzing process ID: {}".format(pid)
     return processes_patches
 
 if __name__ == "__main__":
     patches = get_process_patches()
-    print patches
+    print({}.format(patches))


### PR DESCRIPTION
Hey,

Added support for executables with multiple executable sections, including sections not named '.text'. This resulted in a small refactoring of the analyze_process function, some of which was done in order to improve compatibility with PEP8.
Also added some sanity checks before analyzing the sections' data - whether the executable on disk and memory has the same number of sections, and the same section names (right now, it simply ignores files which fail these checks - this can be improved but I was lazy).

Also, fixed a small bug in analyze_process: 
Line 153 read
current_patch['disk_bytes'] += textSectionData_mem[i]
Instead of
current_patch['disk_bytes'] += textSectionData_disk[i]

I think it would also be nice to add the versions of the dependencies and the version of python on which this was tested to work.

Cheers,
Shay
